### PR TITLE
Apply background update specified views

### DIFF
--- a/media-art-background.js
+++ b/media-art-background.js
@@ -42,6 +42,8 @@ function setBackground(root, appLayout, lovelace, bgroundElem) {
     let entityName = entity.entity || entity;
     let entityValidStates = entity.valid_states || ['playing'];
     let entityImageAttribute = entity.image_attribute || 'entity_picture';
+    let entityValidViews = entity.views; //get a list of valid views
+    let currentview = window.location.pathname.split('/')[2]; // determine current view
 
     let entityInfo = hass.states[entityName];
 
@@ -51,6 +53,10 @@ function setBackground(root, appLayout, lovelace, bgroundElem) {
     }
 
     if (!entityValidStates.includes(entityInfo.state)) continue;
+
+    if (entityValidViews) {
+      if (!entityValidViews.includes(currentview)) continue; //if views have been specified check they match the current view
+    }
 
     const backgroundUrl = entityInfo.attributes[entityImageAttribute];
     if (!backgroundUrl) continue;


### PR DESCRIPTION
Added views as an option to entities

```yaml
media_art_background:
  blur: 10px
  opacity: 0.5
  transition_opacity: 2s
  entities:
    - media_player.main
    - entity: media_player.secondary
      valid_states: ['playing']
      views: ['lovelace_view']
      image_attribute: 'entity_picture'
```

if specified the background will only change when the entity is in the required state and the correct lovelace page is loaded.
If not specified the change will apply to all views.